### PR TITLE
Change to signApiMethod 

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,11 +166,6 @@ var signApiMethod = function (args) {
 
   parameterString += '&oauth_signature=' + signature;
 
-  console.log(cryptoMessage);
-  console.log(cryptoKey);
-  console.log(signature);
-  console.log(parameterString);
-
   var path = '/services/rest';
 
   var httpsOptions = {

--- a/index.js
+++ b/index.js
@@ -127,7 +127,6 @@ var createSortedKeyValuePairString = function (preString, args, keyValueSeparato
  * See documentation for getRequestToken further down below.
  */
 var signApiMethod = function (args) {
-  console.log("** IN SIGN API METHOD **");
   var method = args['method'];
   var flickrConsumerKey = args['flickrConsumerKey'];
   var flickrConsumerKeySecret = args['flickrConsumerKeySecret'];

--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ var createSignature = function (message, key) {
   return signature;
 };
 
-var createSortedKeyValuePairString = function ( preString, args, keyValueSeparator,
-                                                keySeparator, convertFunc) {
+var createSortedKeyValuePairString = function (preString, args, keyValueSeparator, keySeparator, convertFunc) {
   var prop;
   var sortedKeys = [];
   var keyValuePairString = preString;
@@ -128,6 +127,7 @@ var createSortedKeyValuePairString = function ( preString, args, keyValueSeparat
  * See documentation for getRequestToken further down below.
  */
 var signApiMethod = function (args) {
+  console.log("** IN SIGN API METHOD **");
   var method = args['method'];
   var flickrConsumerKey = args['flickrConsumerKey'];
   var flickrConsumerKeySecret = args['flickrConsumerKeySecret'];
@@ -165,6 +165,11 @@ var signApiMethod = function (args) {
                                                         percentEncode);
 
   parameterString += '&oauth_signature=' + signature;
+
+  console.log(cryptoMessage);
+  console.log(cryptoKey);
+  console.log(signature);
+  console.log(parameterString);
 
   var path = '/services/rest';
 

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ var signApiMethod = function (args) {
   }
 
   var cryptoMessage = createSortedKeyValuePairString('POST&https%3A%2F%2F' +
-                                    'api.flickr.com%2Fservices%2Frest',
+                                    'api.flickr.com%2Fservices%2Frest&',
                                     parameters, '%3D', '%26', percentEncodeTwice);
 
   var cryptoKey = flickrConsumerKeySecret + '&' + oauthTokenSecret;


### PR DESCRIPTION
I had been using this package as part of a Meteor application. When I tried to access any methods requiring an oauth signature, however, I would get a signature_invalid error.

It looks like there was an ampersand missing in the parameter string that is used to generate the signature. I can't imagine that this problem wasn't already spotted, so perhaps I have made a mistake. 

However, my application does work now, so I figured I'd submit this edit to be reviewed, at the very least.
